### PR TITLE
Texts are now properly hidden on startup if `sidebar-is-collapsed` is set to true

### DIFF
--- a/src/menu-item-content/eeh-navigation-menu-item-content.html
+++ b/src/menu-item-content/eeh-navigation-menu-item-content.html
@@ -1,3 +1,2 @@
 <span class="menu-item-icon icon-fw {{ iconBaseClass() }} {{ menuItem.iconClass}}"></span>
-<span class="menu-item-text"> {{ menuItem.text|translate }}</span>
-
+<span class="menu-item-text"ng-hide="$parent.sidebarIsCollapsed"> {{ menuItem.text|translate }}</span>

--- a/src/sidebar/eeh-navigation-sidebar-directive.js
+++ b/src/sidebar/eeh-navigation-sidebar-directive.js
@@ -118,30 +118,19 @@ function SidebarDirective($window, eehNavigation) {
             };
             function setTextCollapseState() {
                 var sidebarMenuItems = angular.element(document.querySelectorAll('ul.sidebar-nav:not(.sidebar-nav-nested) > li > a > span'));
-                var sidebarMenuItemText = sidebarMenuItems.find('span');
-                var sidebarMenuItemTextElements = Array.prototype.filter.call(sidebarMenuItemText, function(item){ 
-                                    return item.matches('.menu-item-text');
-                                  });
                 var sidebarMenuItemArrowElements = Array.prototype.filter.call(sidebarMenuItems, function(item){ 
                                     return item.matches('.sidebar-arrow');
                                   });
-                var sidebarMenuItemCombinedElements = sidebarMenuItemArrowElements.concat(sidebarMenuItemTextElements);
                 var sidebarElement = angular.element(document.querySelectorAll('.eeh-navigation-sidebar'));
                 if (scope.sidebarIsCollapsed) {
                     transcludedWrapper.addClass('sidebar-text-collapsed');
                     sidebarElement.addClass('sidebar-text-collapsed');
-                    sidebarMenuItemCombinedElements.forEach(function(menuItem){
-                        angular.element(menuItem).addClass('hidden');
-                    });
                     sidebarMenuItemArrowElements.forEach(function(menuItem){
                         angular.element(menuItem).addClass('hidden');
                     });
                 }else{
                     transcludedWrapper.removeClass('sidebar-text-collapsed');
                     sidebarElement.removeClass('sidebar-text-collapsed');
-                    sidebarMenuItemCombinedElements.forEach(function(menuItem){
-                        angular.element(menuItem).removeClass('hidden');
-                    });
                 }
             }
 


### PR DESCRIPTION
Should fix issue #23.

Text is now hidden with `sidebarIsCollapsed` from parent.
